### PR TITLE
Fix Sagemaker import issue for Numpy 2.0

### DIFF
--- a/deploy_llm_with_ipex_torchserve_sagemaker/E2E-LLM-Sagemaker-IPEX.ipynb
+++ b/deploy_llm_with_ipex_torchserve_sagemaker/E2E-LLM-Sagemaker-IPEX.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "!pip install \"sagemaker>=2.175.0\" --upgrade --quiet\n",
-    "!pip install awscli boto3 botocore numpy s3transfer torch-model-archiver==0.8.1 torchserve==0.8.2 --upgrade --quiet\n",
+    "!pip install awscli boto3 botocore s3transfer torch-model-archiver==0.8.1 torchserve==0.8.2 --upgrade --quiet\n",
     "!pip install huggingface_hub --upgrade --quiet"
    ]
   },
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "ACCOUNT_ID = \"\"\n",
-    "REPOSITORY_NAME = \"pytorch_inference\"\n",
+    "REPOSITORY_NAME = \"\"\n",
     "REGION = \"\"\n",
     "# modify this based on your S3 Bucket name\n",
     "S3_BUCKET_NAME = \"\" # s3://<s3 bucket name>/"
@@ -96,7 +96,7 @@
    "source": [
     "# define these variable names based on S3 Bucket name and ECR url\n",
     "import os\n",
-    "tag = f\"2.2.0-cpu-intel-py310-ubuntu20.04-sagemaker-llm-{current_datetime}\"\n",
+    "tag = f\"2.3.0-cpu-intel-py310-ubuntu20.04-sagemaker-llm-{current_datetime}\"\n",
     "ECR_URL = f\"{ACCOUNT_ID}.dkr.ecr.{REGION}.amazonaws.com/{REPOSITORY_NAME}:{tag}\"\n",
     "S3_URL = os.path.join(S3_BUCKET_NAME, \"llm.tar.gz\")\n",
     "endpoint_name = \"llm-ipex\"\n",


### PR DESCRIPTION
After Numpy 2.0 was released, when running sagemaker with latest numpy, an error appears: `numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject` . This PR fixes this error.